### PR TITLE
Adding a getter for tabview linearLayout

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -185,6 +185,14 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 	public void setOnPageChangeListener(OnPageChangeListener listener) {
 		this.delegatePageListener = listener;
 	}
+	
+	/**
+     	* This method return the tabContainer layout so as to make the tabs nonclickable when orderplace is in progress.
+     	* @return LinearLayout containing the tabs.
+     	*/
+    	public LinearLayout getTabsContainer() {
+        	return tabsContainer;
+    	}
 
 	public void notifyDataSetChanged() {
 


### PR DESCRIPTION
TabView is required inorder to set it non-clickable when place order is on progress.
