### PR TITLE
Adding a getter for tabview linearLayout

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -234,6 +234,13 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             }
         });
     }
+    
+    /**
+    * This method return the tabContainer layout so as to make the tabs nonclickable when orderplace is in progress.     	* @return LinearLayout containing the tabs.
+    */
+   	public LinearLayout getTabsContainer() {
+       	return tabsContainer;
+    }
 
     private void addTextTab(final int position, String title) {
 


### PR DESCRIPTION
TabView is required inorder to set it non-clickable when place order is on progress.
